### PR TITLE
Use the GOROOT indicated by the Go command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for deployment scenarios:
 
 ## Installation
 
-Go 1.6+ is required.
+Go 1.9+ is required.
 
 Build the server with `go build -o grbserver github.com/cespare/grb/cmd/grbserver`. Run `grbserver -h` to see
 the flags options.

--- a/grb_test.go
+++ b/grb_test.go
@@ -46,6 +46,7 @@ func (tg *testGRB) cleanup() {
 }
 
 func (tg *testGRB) build(dir, pkg, bin string) {
+	tg.t.Helper()
 	c := grbConfig{
 		serverURL: tg.server.URL,
 		out:       bin,
@@ -59,6 +60,7 @@ func (tg *testGRB) build(dir, pkg, bin string) {
 }
 
 func (tg *testGRB) run(bin string) string {
+	tg.t.Helper()
 	out, err := exec.Command(bin).Output()
 	if err != nil {
 		tg.t.Fatalf("Error running test program: %s", err)


### PR DESCRIPTION
By default, we're using the one that grb was built with. We should make
sure that if Go is upgraded and GOROOT changes, we pick up the new one
instead.